### PR TITLE
Documentation - fixed python file name for shopware api client in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ Start shopware-demo shopware instance and set client credentials
 ```bash
 docker run --rm -p 8000:80 dockware/play
 
-python3 .github/api_credentials.py
+python3 .github/api_sw_client.py
 ```
 
 _Python Library:_ `pip install requests`


### PR DESCRIPTION
It seems that the name of the file `.github/api_credentials.py` has been changed to `.github/api_sw_client.py`. I updated the readme to match the current state.